### PR TITLE
use default path to proxy if $X509_USER_PROXY is not set

### DIFF
--- a/ada/ada
+++ b/ada/ada
@@ -222,7 +222,7 @@ while [ $# -gt 0 ] ; do
       case $2 in
         --* | '' )
           # Next argument is another option or absent; not a file name
-          proxyfile="$X509_USER_PROXY"
+          proxyfile="${X509_USER_PROXY:-/tmp/x509up_u${UID}}"
           ;;
         * )
           # This must be a file name


### PR DESCRIPTION
Hi Onno,

VOMS tools use default path to /tmp/x509up_u${UID}. ada should use that, too.