### PR TITLE
Fixes in bulk staging function

### DIFF
--- a/ada/ada
+++ b/ada/ada
@@ -921,7 +921,7 @@ bulk_request() {
     target=${target%?}]
   fi
   arguments="{\"lifetime\": \"${lifetime}\", \"lifetimeUnit\":\"${lifetime_unit}\"}, \"target\": ${target}, \"expand_directories\": \"${expand}\"}"
-  $debug || echo "$path  "
+  $debug || echo "$target  "
   (
     $debug && set -x   # If --debug is specified, show (only) curl command 
     curl "${curl_authorization[@]}" \
@@ -931,7 +931,7 @@ bulk_request() {
          -d "{ \"activity\": \"${activity}\", \"arguments\": ${arguments}"\
          --dump-header - 
   ) | grep -e request-url -e Date >> "${requests_log}"
-  echo "target: $path" >> $requests_log
+  echo "target: $target" >> $requests_log
   echo " " >> $requests_log
 }
 

--- a/ada/ada
+++ b/ada/ada
@@ -930,7 +930,7 @@ bulk_request() {
          -X POST "$api/bulk-requests"\
          -d "{ \"activity\": \"${activity}\", \"arguments\": ${arguments}"\
          --dump-header - 
-  ) | grep -e request-url -e Date >> "${requests_log}"
+  ) | grep -e request-url -e Date | tee -a "${requests_log}"
   echo "activity: $activity" >> $requests_log
   echo "target: $target" >> $requests_log
   echo " " >> $requests_log

--- a/ada/ada
+++ b/ada/ada
@@ -931,6 +931,7 @@ bulk_request() {
          -d "{ \"activity\": \"${activity}\", \"arguments\": ${arguments}"\
          --dump-header - 
   ) | grep -e request-url -e Date >> "${requests_log}"
+  echo "activity: $activity" >> $requests_log
   echo "target: $target" >> $requests_log
   echo " " >> $requests_log
 }

--- a/ada/ada
+++ b/ada/ada
@@ -107,7 +107,7 @@ usage() {
 	      If --lifetime is not given, default is 7D.
 	  --stage <directory> [--recursive]
 	      Stage files in directory.
-	  --stage --from-file <file-list> [--recursive]
+	  --stage --from-file <file-list>
 	      Stage files or directories in the list.
 
 	  --unstage <file>
@@ -881,26 +881,46 @@ bulk_request() {
   local activity="$1"
   local path="$2"
   local recursive="$3"
-  type=$(pathtype "$path")
-  case $type in
-    DIR )
-      if $recursive ; then
-        expand=ALL
-      else
-        expand=TARGETS
-      fi
-      ;;
-    REGULAR | LINK )
-      expand=NONE
-      ;;
-    '' )
-      echo "Warning: could not determine object type of '$path'."
-      ;;
-    * )
-      echo "Unknown object type '$type'. Please create an issue for this in Github."
-      ;;
-  esac
-  arguments="{\"lifetime\": \"${lifetime}\", \"lifetimeUnit\":\"${lifetime_unit}\"}, \"target\": [\"/${path}\"], \"expand_directories\": \"${expand}\"}"
+  if [ "$from_file" == false ] ; then
+    get_locality "$pathlist"
+    error=$?
+    if [ "$error" == 1 ] ; then
+      echo 1>&2 "Error: '$pathlist' does not exist."
+      exit 1
+    fi
+    type=$(pathtype "$path")
+    case $type in
+      DIR )
+        if $recursive ; then
+          expand=ALL
+        else
+          expand=TARGETS
+        fi
+        ;;
+      REGULAR | LINK )
+        expand=NONE
+        ;;
+      '' )
+        echo "Warning: could not determine object type of '$path'."
+        ;;
+      * )
+        echo "Unknown object type '$type'. Please create an issue for this in Github."
+        ;;
+    esac
+  else
+    if $recursive ; then
+      echo 1>&2 "Error: recursive (un)staging forbidden when using file-list."
+      exit 1
+    else
+      expand=TARGETS
+    fi
+    target='['
+    while read -r path ; do
+      target=$target\"/${path}\",
+    done <<<"$pathlist"
+    target=${target%?}]
+  fi
+  arguments="{\"lifetime\": \"${lifetime}\", \"lifetimeUnit\":\"${lifetime_unit}\"}, \"target\": ${target}, \"expand_directories\": \"${expand}\"}"
   $debug || echo "$path  "
   (
     $debug && set -x   # If --debug is specified, show (only) curl command 
@@ -1464,18 +1484,7 @@ case $command in
       stage   )  activity='PIN'     ;;
       unstage )  activity='UNPIN'   ;;
     esac
-    if [ "$from_file" == false ] ; then
-        get_locality "$pathlist"
-        error=$?
-        if [ "$error" == 1 ] ; then
-          echo 1>&2 "Error: '$pathlist' does not exist."
-          exit 1
-        fi
-    fi
-    while read -r path ; do
-      bulk_request "$activity" "$path" "$recursive"
-    done <<<"$pathlist" \
-    | column -t -s $'\t'
+    bulk_request "$activity" "$pathlist" "$recursive" | column -t -s $'\t'
     ;;
   events | report-staged )
     if [ "${BASH_VERSINFO[0]}" -lt 4 ] ; then

--- a/ada/ada
+++ b/ada/ada
@@ -882,13 +882,14 @@ bulk_request() {
   local pathlist="$2"
   local recursive="$3"
   if [ "$from_file" == false ] ; then
-    get_locality "$pathlist"
+    local filepath="$2"
+    get_locality "$filepath"
     error=$?
     if [ "$error" == 1 ] ; then
-      echo 1>&2 "Error: '$pathlist' does not exist."
+      echo 1>&2 "Error: '$filepath' does not exist."
       exit 1
     fi
-    type=$(pathtype "$pathlist")
+    type=$(pathtype "$filepath")
     case $type in
       DIR )
         if $recursive ; then
@@ -901,7 +902,7 @@ bulk_request() {
         expand=NONE
         ;;
       '' )
-        echo "Warning: could not determine object type of '$pathlist'."
+        echo "Warning: could not determine object type of '$filepath'."
         ;;
       * )
         echo "Unknown object type '$type'. Please create an issue for this in Github."

--- a/ada/ada
+++ b/ada/ada
@@ -931,6 +931,7 @@ bulk_request() {
          -d "{ \"activity\": \"${activity}\", \"arguments\": ${arguments}"\
          --dump-header - 
   ) | grep -e request-url -e Date | tee -a "${requests_log}"
+  $debug && echo "Information about bulk requests is logged in $requests_log."
   echo "activity: $activity" >> $requests_log
   echo "target: $target" >> $requests_log
   echo " " >> $requests_log

--- a/ada/ada
+++ b/ada/ada
@@ -879,7 +879,7 @@ get_locality () {
 
 bulk_request() {
   local activity="$1"
-  local path="$2"
+  local pathlist="$2"
   local recursive="$3"
   if [ "$from_file" == false ] ; then
     get_locality "$pathlist"
@@ -888,7 +888,7 @@ bulk_request() {
       echo 1>&2 "Error: '$pathlist' does not exist."
       exit 1
     fi
-    type=$(pathtype "$path")
+    type=$(pathtype "$pathlist")
     case $type in
       DIR )
         if $recursive ; then
@@ -901,7 +901,7 @@ bulk_request() {
         expand=NONE
         ;;
       '' )
-        echo "Warning: could not determine object type of '$path'."
+        echo "Warning: could not determine object type of '$pathlist'."
         ;;
       * )
         echo "Unknown object type '$type'. Please create an issue for this in Github."
@@ -914,11 +914,6 @@ bulk_request() {
     else
       expand=TARGETS
     fi
-    target='['
-    while read -r path ; do
-      target=$target\"/${path}\",
-    done <<<"$pathlist"
-    target=${target%?}]
   fi
   case $activity in
     PIN   )    
@@ -926,6 +921,11 @@ bulk_request() {
     UNPIN )    
       arguments="{}" ;;
   esac
+  target='['
+  while read -r path ; do
+    target=$target\"/${path}\",
+  done <<<"$pathlist"
+  target=${target%?}]
   data="{\"activity\": \"${activity}\", \"arguments\": ${arguments}, \"target\": ${target}, \"expand_directories\": \"${expand}\"}"
   $debug || echo "$target  "
   (

--- a/ada/ada
+++ b/ada/ada
@@ -920,7 +920,13 @@ bulk_request() {
     done <<<"$pathlist"
     target=${target%?}]
   fi
-  arguments="{\"lifetime\": \"${lifetime}\", \"lifetimeUnit\":\"${lifetime_unit}\"}, \"target\": ${target}, \"expand_directories\": \"${expand}\"}"
+  case $activity in
+    PIN   )    
+      arguments="{\"lifetime\": \"${lifetime}\", \"lifetimeUnit\":\"${lifetime_unit}\"}" ;;
+    UNPIN )    
+      arguments="{}" ;;
+  esac
+  data="{\"activity\": \"${activity}\", \"arguments\": ${arguments}, \"target\": ${target}, \"expand_directories\": \"${expand}\"}"
   $debug || echo "$target  "
   (
     $debug && set -x   # If --debug is specified, show (only) curl command 
@@ -928,10 +934,10 @@ bulk_request() {
          "${curl_options_common[@]}" \
          "${curl_options_post[@]}" \
          -X POST "$api/bulk-requests"\
-         -d "{ \"activity\": \"${activity}\", \"arguments\": ${arguments}"\
+         -d "${data}" \
          --dump-header - 
   ) | grep -e request-url -e Date | tee -a "${requests_log}"
-  $debug && echo "Information about bulk requests is logged in $requests_log."
+  $debug && echo "Information about bulk request is logged in $requests_log."
   echo "activity: $activity" >> $requests_log
   echo "target: $target" >> $requests_log
   echo " " >> $requests_log

--- a/ada/ada
+++ b/ada/ada
@@ -939,7 +939,7 @@ bulk_request() {
   ) | grep -e request-url -e Date | tee -a "${requests_log}"
   $debug && echo "Information about bulk request is logged in $requests_log."
   echo "activity: $activity" >> $requests_log
-  echo "target: $target" >> $requests_log
+  echo "target: $target" | sed 's/,/,\n         /g' >> $requests_log
   echo " " >> $requests_log
 }
 


### PR DESCRIPTION
Fixes to bulk staging:
- Stage file-list as array in a single bulk request
- Put target in requests.log
- Add activity (PIN ur UNPIN) of bulk request in requests.log
- Except for storing the request ID in ~/.ada/requests.log, return the request ID to the prompt when a stage/unstage command is submitted.
- In debug mode, mention that information about bulk request is logged in requests.log
- Remove default lifetime from unstage/unpin command