### PR TITLE
Define fallback value for --version option

### DIFF
--- a/ada/ada
+++ b/ada/ada
@@ -283,7 +283,8 @@ while [ $# -gt 0 ] ; do
       usage
       ;;
     --version )
-      git describe --tags --abbrev=0
+      _VERSION_PLACEHOLDER=$(git describe --tags --abbrev=0 2>/dev/null || echo "unknown")
+      echo "${_VERSION_PLACEHOLDER}"
       exit 1
       ;;      
     --tokenfile )


### PR DESCRIPTION
The `--version` option relies on `git describe` command to determine the software version. This requires the script to be located within a valid git repository, which may not always be the case.

This patch tries to determine the software version using git and adds a fallback value (`unknown`) in case this is not possible.

Using the variable `_VERSION_PLACEHOLDER` allows third party tools such as Ansible to edit this specific line with the proper version at the time of deployment.