### PR TITLE
Use ada/etc/ada.conf if it exists 

### DIFF
--- a/ada/ada
+++ b/ada/ada
@@ -7,7 +7,7 @@
 # Latest version is available at: https://github.com/sara-nl/SpiderScripts
 #
 # Changes:
-# 2025-02-18 - Haili   - Read config from ./etc/ada.conf (as last option)
+# 2025-02-18 - Haili   - Read config from <script_dir>/etc/ada.conf (as last option)
 # 2025-01-14 - Onno    - Add support for extended attributes
 # 2024-12-30 - Onno    - Add support for labels
 # 2024-12-27 - Onno    - Improved token validation
@@ -217,7 +217,7 @@ usage() {
 
 	Configuration files:
 
-	  Default values can be stored in ~/.ada/ada.conf, /etc/ada.conf and ./etc/ada.conf
+	  Default values can be stored in ~/.ada/ada.conf, /etc/ada.conf and <script_dir>/etc/ada.conf
 	  For example:
 	  api='https://prometheus.desy.de:3880/api/v1/'
 
@@ -245,7 +245,7 @@ usage() {
 	    2. environment variables
 	    3. ~/.ada/ada.conf
 	    4. /etc/ada.conf
-	    5. ./etc/ada.conf
+	    5. <script_dir>/etc/ada.conf
 
 	Examples:
 	  $0 ... (todo)

--- a/ada/ada
+++ b/ada/ada
@@ -7,6 +7,7 @@
 # Latest version is available at: https://github.com/sara-nl/SpiderScripts
 #
 # Changes:
+# 2025-02-18 - Haili   - Read config from ./etc/ada.conf (as last option)
 # 2025-01-14 - Onno    - Add support for extended attributes
 # 2024-12-30 - Onno    - Add support for labels
 # 2024-12-27 - Onno    - Improved token validation
@@ -296,7 +297,7 @@ set_defaults() {
                         --fail --silent --show-error
                       )
 
-  # Load defaults from configuration file if exists 
+  # Load defaults from configuration file if exists
   declare -a configfiles=( "${script_dir}"/etc/ada.conf /etc/ada.conf ~/.ada/ada.conf )
   for configfile in "${configfiles[@]}" ; do
     if [ -f "$configfile" ] ; then

--- a/ada/ada
+++ b/ada/ada
@@ -216,7 +216,7 @@ usage() {
 
 	Configuration files:
 
-	  Default values can be stored in /etc/ada.conf and ~/.ada/ada.conf.
+	  Default values can be stored in ~/.ada/ada.conf, /etc/ada.conf and ./etc/ada.conf
 	  For example:
 	  api='https://prometheus.desy.de:3880/api/v1/'
 
@@ -244,7 +244,7 @@ usage() {
 	    2. environment variables
 	    3. ~/.ada/ada.conf
 	    4. /etc/ada.conf
-
+	    5. ./etc/ada.conf
 
 	Examples:
 	  $0 ... (todo)
@@ -296,11 +296,10 @@ set_defaults() {
                         --fail --silent --show-error
                       )
 
-  # Load defaults from configuration file if exists
-  declare -a configfiles=( /etc/ada.conf ~/.ada/ada.conf )
+  # Load defaults from configuration file if exists 
+  declare -a configfiles=( "${script_dir}"/etc/ada.conf /etc/ada.conf ~/.ada/ada.conf )
   for configfile in "${configfiles[@]}" ; do
     if [ -f "$configfile" ] ; then
-      $debug && echo "Loading $configfile"
       source "$configfile"
     fi
   done

--- a/ada/etc/ada.conf
+++ b/ada/etc/ada.conf
@@ -1,6 +1,6 @@
 # Default settings for the ADA script
 
-#api=https://dolphin12.grid.surfsara.nl:20443/api/v1
+#api=https://dcachetest.grid.surfsara.nl:20443/api/v1
 api=https://dcacheview.grid.surfsara.nl:22880/api/v1
 
 # Adding --ipv4 to the default curl options.

--- a/ada/etc/ada.conf
+++ b/ada/etc/ada.conf
@@ -1,6 +1,6 @@
 # Default settings for the ADA script
 
-#api=https://dcachetest.grid.surfsara.nl:20443/api/v1
+#api=https://dolphin12.grid.surfsara.nl:20443/api/v1
 api=https://dcacheview.grid.surfsara.nl:22880/api/v1
 
 # Adding --ipv4 to the default curl options.


### PR DESCRIPTION
 Tell Ada to look for an ada.conf in the same dir as where the script is (last in order of preference after /etc/ada.conf and ~/.ada/ada.conf).

Not that $debug is always false when ada.conf is sourced, because the env variables and commandline arguments are set later. So I removed the line:
```
$debug && echo "Loading $configfile"
```