### PR TITLE
Fail early when token is about to expire

### DIFF
--- a/ada/ada
+++ b/ada/ada
@@ -685,7 +685,11 @@ view_token() {
     echo "$payload" | jq '. | .exp |= todate | .nbf |= todate | .iat |= todate'
   else
     # Not an OIDC token; probably a Macaroon
-    macaroon_decoded=$(echo "$token" | base64 -d 2>/dev/null | awk '{print substr($0, 5)}' 2>/dev/null | tr -d '\0')
+    macaroon_decoded=$(echo "$token" \
+                       | base64 -d 2>/dev/null \
+                       | awk '{print substr($0, 5)}' 2>/dev/null \
+                       | grep -v 'signature' \
+                       | tr -d '\0')
 
     # Check if decoding succeeded
     if [ -z "$macaroon_decoded" ]; then
@@ -693,8 +697,7 @@ view_token() {
       return 1
     fi
 
-    # Show macaroon without signature
-    echo -e "\033[34m\n$macaroon_decoded\n\033[0m" | grep -v 'signature' | sed -e 's/^/  /'
+    echo -e "\033[34m\n$macaroon_decoded\n\033[0m" | sed -e 's/^/  /'
   fi
 }
 
@@ -772,7 +775,11 @@ check_token() {
     # Macaroon Token (assume it's base64 encoded)
     $debug && echo "Checking Macaroon token..."
 
-    macaroon_decoded=$(echo "$token" | base64 -d 2>/dev/null | awk '{print substr($0, 5)}' 2>/dev/null | tr -d '\0')
+    macaroon_decoded=$(echo "$token" \
+                       | base64 -d 2>/dev/null \
+                       | awk '{print substr($0, 5)}' 2>/dev/null \
+                       | grep -v 'signature' \
+                       | tr -d '\0')
 
     # Check if decoding succeeded
     if [ -z "$macaroon_decoded" ]; then
@@ -807,7 +814,7 @@ check_token() {
     validate_expiration_timestamp "$exp_unix" "$min_valid_time" "$token_debug_info"
 
     # If we get here, it means we have a valid macaroon.
-    $debug && echo -e "\033[34m\n$macaroon_decoded\n\033[0m" | grep -v 'signature' | sed -e 's/^/  /'
+    $debug && echo -e "\033[34m\n$macaroon_decoded\n\033[0m" | sed -e 's/^/  /'
     $debug && echo "Macaroon is valid"
     return 0
   fi

--- a/ada/ada
+++ b/ada/ada
@@ -700,9 +700,49 @@ view_token() {
 
 
 
+validate_expiration_timestamp () {
+  local exp_unix="$1"           # Expiration timestamp (unix format)
+  local min_valid_time="$2"     # Token should be valid for more that this many seconds
+  local token_debug_info="$3"   # Additional info for error message
+
+  # Do we actually have an expiration timestamp?
+  if [ -z "$exp_unix" ] || ! [[ "$exp_unix" =~ ^[0-9]+$ ]]; then
+    echo 1>&2 "ERROR: Invalid token: missing or invalid expiration field"
+    echo 1>&2 "$token_debug_info"
+    exit 1
+  fi
+
+  # Get the current time in seconds since epoch
+  now=$(date +%s)
+
+  # Check if the token is expired
+  if [ "$now" -ge "$exp_unix" ]; then
+    echo 1>&2 "$token_debug_info"
+    echo 1>&2 "ERROR: Token has expired $(( now - exp_unix )) seconds ago."
+    exit 1
+  fi
+
+  # Check if the token is about to expire
+  if [ "$now" -ge "$(( exp_unix - min_valid_time ))" ]; then
+    echo 1>&2 "$token_debug_info"
+    # print error
+    echo 1>&2 "ERROR: Token will expire in $(( exp_unix - now )) seconds." \
+              "Please use a token that is valid for more than $min_valid_time seconds," \
+              "to ensure Ada can finish the task."
+    exit 1
+  fi
+
+  # If we get here, the expiration timestamp should be valid.
+  return 0
+}
+
+
 check_token() {
   local token="$1"
   local token_debug_info="$2"
+  # We're not starting with a token that is about to expire!
+  # The minimum lifetime is 10 seconds, unless specified otherwise in $3.
+  local min_valid_time="${3:-10}"
 
   # Determine token type (JWT or Macaroon)
   if [[ "$token" =~ ^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$ ]]; then
@@ -718,27 +758,10 @@ check_token() {
     fi
 
     # Extract expiration time (exp) from payload
-    exp=$(echo "$payload" | jq -r '.exp' 2>/dev/null)
+    exp_unix=$(echo "$payload" | jq -r '.exp' 2>/dev/null)
 
-    # Validate expiration field
-    if [ -z "$exp" ] || ! [[ "$exp" =~ ^[0-9]+$ ]]; then
-      echo 1>&2 "ERROR: Invalid token: missing or invalid 'exp' field"
-      echo 1>&2 "$token_debug_info"
-      return 1
-    fi
-
-    # Get the current time in seconds since epoch
-    now=$(date +%s)
-
-    # Check if the token is expired
-    if [ "$now" -ge "$exp" ]; then
-      echo 1>&2 "$token_debug_info"
-      # Print JWT/OIDC token with human readable timestamps
-      echo "$payload" | jq '. | .exp |= todate | .nbf |= todate | .iat |= todate' 1>&2
-      # print error
-      echo 1>&2 "ERROR: JWT / OIDC token has expired $(( now - exp )) seconds ago."
-      return 1
-    fi
+    # Fail if the token has (almost) expired
+    validate_expiration_timestamp "$exp_unix" "$min_valid_time" "$token_debug_info"
 
     # If we get here, it means we have a valid OIDC token.
     $debug && echo "$payload" | jq '. | .exp |= todate | .nbf |= todate | .iat |= todate'
@@ -768,30 +791,20 @@ check_token() {
       return 1
     fi
 
-    # Convert expiration time to epoch seconds
+    # Convert expiration time to unix time (seconds since epoch)
     case $OSTYPE in
-      darwin* )  exp_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%S" "${exp:0:19}" +"%s" 2>/dev/null)  ;;
-            * )  exp_epoch=$(date -d "$exp" +%s 2>/dev/null)  ;;
+      darwin* )  exp_unix=$(date -u -j -f "%Y-%m-%dT%H:%M:%S" "${exp:0:19}" +"%s" 2>/dev/null)  ;;
+            * )  exp_unix=$(date -d "$exp" +%s 2>/dev/null)  ;;
     esac
 
-    if [ -z "$exp_epoch" ]; then
+    if [ -z "$exp_unix" ]; then
       echo 1>&2 "ERROR: invalid macaroon: unable to parse 'before' timestamp"
       echo 1>&2 "$token_debug_info"
       return 1
     fi
 
-    # Get the current time in UTC in seconds since epoch
-    now=$(date +%s)
-
-    # Check if the macaroon is expired
-    if [ "$now" -ge "$exp_epoch" ]; then
-      echo 1>&2 "$token_debug_info"
-      # Show macaroon without signature
-      echo -e "\033[34m\n$macaroon_decoded\n\033[0m" | grep -v 'signature' | sed -e 's/^/  /' 1>&2
-      # Show error
-      echo 1>&2 "ERROR: Macaroon has expired $((now - exp_epoch)) seconds ago."
-      return 1
-    fi
+    # Fail if the token has (almost) expired
+    validate_expiration_timestamp "$exp_unix" "$min_valid_time" "$token_debug_info"
 
     # If we get here, it means we have a valid macaroon.
     $debug && echo -e "\033[34m\n$macaroon_decoded\n\033[0m" | grep -v 'signature' | sed -e 's/^/  /'
@@ -1734,7 +1747,16 @@ validate_input() {
         echo 1>&2 "ERROR: no tokenfile, nor variable BEARER_TOKEN specified."
         exit 1
       fi
-      check_token "$token" || exit 1
+      # Token should be valid - unless we want to view the token!
+      # We should be able to view also invalid tokens (to check what's wrong with them).
+      if [[ $command != 'viewtoken' ]] ; then
+        if $recursive ; then
+          # For recursive operations, we want the token to be valid for at least 60 seconds.
+          check_token "$token" "$token_debug_info" 60 || exit 1
+        else
+          check_token "$token" "$token_debug_info" || exit 1
+        fi
+      fi
       ;;
     netrc )
       if [ ! -f "$netrcfile" ] ; then

--- a/ada/ada
+++ b/ada/ada
@@ -7,6 +7,7 @@
 # Latest version is available at: https://github.com/sara-nl/SpiderScripts
 #
 # Changes:
+# 2025-02-20 - Onno.   - Fail early when a token is about to expire
 # 2025-02-18 - Haili   - Read config from <script_dir>/etc/ada.conf (as last option)
 # 2025-01-14 - Onno    - Add support for extended attributes
 # 2024-12-30 - Onno    - Add support for labels

--- a/ada/ada
+++ b/ada/ada
@@ -7,7 +7,7 @@
 # Latest version is available at: https://github.com/sara-nl/SpiderScripts
 #
 # Changes:
-# 2025-02-20 - Onno.   - Fail early when a token is about to expire
+# 2025-02-20 - Onno    - Fail early when a token is about to expire
 # 2025-02-18 - Haili   - Read config from <script_dir>/etc/ada.conf (as last option)
 # 2025-01-14 - Onno    - Add support for extended attributes
 # 2024-12-30 - Onno    - Add support for labels

--- a/ada/ada
+++ b/ada/ada
@@ -705,8 +705,8 @@ view_token() {
 
 validate_expiration_timestamp () {
   local exp_unix="$1"           # Expiration timestamp (unix format)
-  local min_valid_time="$2"     # Token should be valid for more that this many seconds
-  local token_debug_info="$3"   # Additional info for error message
+  local token_debug_info="$2"   # Additional info for error message
+  local min_valid_time=60       # Token should be valid for more that this many seconds
 
   # Do we actually have an expiration timestamp?
   if [ -z "$exp_unix" ] || ! [[ "$exp_unix" =~ ^[0-9]+$ ]]; then
@@ -743,9 +743,6 @@ validate_expiration_timestamp () {
 check_token() {
   local token="$1"
   local token_debug_info="$2"
-  # We're not starting with a token that is about to expire!
-  # The minimum lifetime is 10 seconds, unless specified otherwise in $3.
-  local min_valid_time="${3:-10}"
 
   # Determine token type (JWT or Macaroon)
   if [[ "$token" =~ ^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$ ]]; then
@@ -764,7 +761,7 @@ check_token() {
     exp_unix=$(echo "$payload" | jq -r '.exp' 2>/dev/null)
 
     # Fail if the token has (almost) expired
-    validate_expiration_timestamp "$exp_unix" "$min_valid_time" "$token_debug_info"
+    validate_expiration_timestamp "$exp_unix" "$token_debug_info"
 
     # If we get here, it means we have a valid OIDC token.
     $debug && echo "$payload" | jq '. | .exp |= todate | .nbf |= todate | .iat |= todate'
@@ -811,7 +808,7 @@ check_token() {
     fi
 
     # Fail if the token has (almost) expired
-    validate_expiration_timestamp "$exp_unix" "$min_valid_time" "$token_debug_info"
+    validate_expiration_timestamp "$exp_unix" "$token_debug_info"
 
     # If we get here, it means we have a valid macaroon.
     $debug && echo -e "\033[34m\n$macaroon_decoded\n\033[0m" | sed -e 's/^/  /'
@@ -1757,12 +1754,7 @@ validate_input() {
       # Token should be valid - unless we want to view the token!
       # We should be able to view also invalid tokens (to check what's wrong with them).
       if [[ $command != 'viewtoken' ]] ; then
-        if $recursive ; then
-          # For recursive operations, we want the token to be valid for at least 60 seconds.
-          check_token "$token" "$token_debug_info" 60 || exit 1
-        else
-          check_token "$token" "$token_debug_info" || exit 1
-        fi
+        check_token "$token" "$token_debug_info" || exit 1
       fi
       ;;
     netrc )


### PR DESCRIPTION
* Fail when token will expire in 10 seconds
* Fail when token will expire in 60 seconds, when `--recursive` was specified
* Fix `date` command for MacOS; added -u to assume UTC instead of local time
* Don't validate token when command is `--viewtoken`, because we want to view tokens that are invalid.
* Fix: `tr: Illegal byte sequence`
