### PR TITLE
Fix find command for Linux; use access time instead of modification time

### DIFF
--- a/ada/ada
+++ b/ada/ada
@@ -816,8 +816,8 @@ setup_dirs () {
   # The users are supposed to do that themselves.
   # But they might forget, and keeping the header files for too long
   # might not be very safe on a shared system.
-  # So, we clean up all header files older than 10 hours.
-  find "$ada_dir"/headers -type f -name 'authorization_header_*' -mtime +10h -delete
+  # So, we clean up all header files that haven't been used for 10 hours.
+  find "$ada_dir"/headers -type f -name 'authorization_header_*' -amin +600 -delete
 }
 
 


### PR DESCRIPTION
* Linux doesn't understand `-mtime +10h`
* Used -amin (access) instead of -mmin (modification) because then we won't delete files that are actively used