### PR TITLE
Fix failure running intergration test when tokenfile is newly created

### DIFF
--- a/tests/integration_test.sh
+++ b/tests/integration_test.sh
@@ -373,6 +373,7 @@ oneTimeSetUp() {
             echo "Failed to create a macaroon. Aborting." 
             exit 
         fi
+        token=$(sed -n 's/^bearer_token *= *//p' "$token_file")
     fi
     # curl options for various activities;
     curl_options_common=(


### PR DESCRIPTION
After token is created, this need to be loaded for all integration tests to succeed.