### PR TITLE
Check unique channel name

### DIFF
--- a/ada/ada
+++ b/ada/ada
@@ -180,11 +180,13 @@ usage() {
 	  --unstage --from-file <file-list>
 	      Release files in the list.
 
-	  --events <channel-name> <path-to-follow> [--resume] [--recursive] [--timeout s]
+	  --events <channel-name> <path-to-follow> [--resume] [--force] [--recursive] [--timeout s]
 	      Subscribe to changes in the given direcory,
 	      using server-sent events (SSE).
-	      If channel-name is already in use, you must add --resume
+	      If channel name is already in use, you must add --resume
 	      to resume following this channel. 
+        If the channel name is not stored locally, you must also 
+        add --force to resume,
 	      When --recursive is added, all subdirectories will be
 	      followed as well, including any new subdirectories
 	      that will be created.
@@ -193,11 +195,13 @@ usage() {
 	      after this timeout. Events that have not been processed
 	      will then be lost.
 
-	  --report-staged <channel-name> <path-to-follow> [--resume] [--recursive] [--timeout s]
+	  --report-staged <channel-name> <path-to-follow> [--resume] [--force] [--recursive] [--timeout s]
 	      Subscribe to stage (bring online) events in a directory,
 	      using server-sent events (SSE).
-	      If channel-name is already in use, you must add --resume
-	      to resume following this channel. 
+	      If channel name is already in use, you must add --resume
+	      to resume following this channel.
+        If the channel name is not stored locally, you must also 
+        add --force to resume,
 	      This command is slightly different from --events:
 	      When you start it, all files in the scope will be listed,
 	      including their locality and QoS. This allows your event
@@ -2402,6 +2406,7 @@ api_call () {
         exit 1
       fi
       channel=$(get_channel_by_name "$channelname")
+      channel_id=$(basename "$channel")
       if [ "$channel" = "" ] ; then
         # Channel doesn't exist; create it.
         (
@@ -2411,10 +2416,8 @@ api_call () {
                "${curl_options_post[@]}" \
                -X POST "$api/events/channels" -d "{\"client-id\":\"$channelname\"}"
         )
-        channel=$(get_channel_by_name "$channelname")
         # There is no API call to translate channel ID back to
         # channel name. So we keep track of the name ourselves.
-        channel_id=$(basename "$channel")
         echo "$channelname" > "${ada_dir}/channels/channel-name-${channel_id}"
         # Set channel timeout
         (
@@ -2426,7 +2429,12 @@ api_call () {
                -d "{\"timeout\": $channel_timeout}"
         )
       elif ! $resume ; then
+        # Channel already exists; add --resume to continue
         echo 1>&2 "ERROR: channel name '$channelname' is already used. To resume following this channel, add  --resume."
+        exit 1
+      elif [ ! -f "${ada_dir}/channels/channel-name-${channel_id}" ] && ! $force ; then
+        # Channel already exists but channelname was not saved locally; add --resume and --force to continue      
+        echo 1>&2 "ERROR: channel name '$channelname' is already used but was not saved locally. Add --force if you still want to resume."
         exit 1
       fi
       echo "Channel: $channel"

--- a/ada/ada
+++ b/ada/ada
@@ -186,8 +186,8 @@ usage() {
 	      using server-sent events (SSE).
 	      If channel name is already in use, you must add --resume
 	      to resume following this channel. 
-        If the channel name is not stored locally, you must also 
-        add --force to resume,
+	      If the channel name is not stored locally, you must also 
+	      add --force to resume,
 	      When --recursive is added, all subdirectories will be
 	      followed as well, including any new subdirectories
 	      that will be created.
@@ -201,8 +201,8 @@ usage() {
 	      using server-sent events (SSE).
 	      If channel name is already in use, you must add --resume
 	      to resume following this channel.
-        If the channel name is not stored locally, you must also 
-        add --force to resume,
+	      If the channel name is not stored locally, you must also 
+	      add --force to resume,
 	      This command is slightly different from --events:
 	      When you start it, all files in the scope will be listed,
 	      including their locality and QoS. This allows your event

--- a/ada/ada
+++ b/ada/ada
@@ -7,6 +7,7 @@
 # Latest version is available at: https://github.com/sara-nl/SpiderScripts
 #
 # Changes:
+# 2025-04-10 - Haili   - Add options --resume and --force to events and report-staged
 # 2025-02-20 - Onno    - Fail early when a token is about to expire
 # 2025-02-18 - Haili   - Read config from <script_dir>/etc/ada.conf (as last option)
 # 2025-01-14 - Onno    - Add support for extended attributes

--- a/ada/ada
+++ b/ada/ada
@@ -180,9 +180,11 @@ usage() {
 	  --unstage --from-file <file-list>
 	      Release files in the list.
 
-	  --events <channel-name> <path-to-follow> [--recursive] [--timeout s]
+	  --events <channel-name> <path-to-follow> [--resume] [--recursive] [--timeout s]
 	      Subscribe to changes in the given direcory,
 	      using server-sent events (SSE).
+	      If channel-name is already in use, you must add --resume
+	      to resume following this channel. 
 	      When --recursive is added, all subdirectories will be
 	      followed as well, including any new subdirectories
 	      that will be created.
@@ -191,9 +193,11 @@ usage() {
 	      after this timeout. Events that have not been processed
 	      will then be lost.
 
-	  --report-staged <channel-name> <path-to-follow> [--recursive] [--timeout s]
+	  --report-staged <channel-name> <path-to-follow> [--resume] [--recursive] [--timeout s]
 	      Subscribe to stage (bring online) events in a directory,
 	      using server-sent events (SSE).
+	      If channel-name is already in use, you must add --resume
+	      to resume following this channel. 
 	      This command is slightly different from --events:
 	      When you start it, all files in the scope will be listed,
 	      including their locality and QoS. This allows your event
@@ -293,6 +297,7 @@ set_defaults() {
   path=
   recursive=false
   force=false
+  resume=false
 
   # Default options to curl for various activities;
   # these can be overidden in configuration files, see below.
@@ -609,6 +614,10 @@ get_args() {
         force=true
         shift
         ;;
+      --resume )
+        resume=true
+        shift
+        ;;        
       --lifetime )
         arg="$2"
         lifetime=${arg::${#arg} -1}
@@ -2416,6 +2425,9 @@ api_call () {
                -X PATCH "$channel" \
                -d "{\"timeout\": $channel_timeout}"
         )
+      elif ! $resume ; then
+        echo 1>&2 "ERROR: channel name '$channelname' is already used. To resume following this channel, add  --resume."
+        exit 1
       fi
       echo "Channel: $channel"
       channel_subscribe "$channel" "$path" "$recursive"

--- a/tests/integration_test.sh
+++ b/tests/integration_test.sh
@@ -36,7 +36,7 @@ test_ada_mkdir() {
 
 # Subscribe to events in dCache folder
 test_ada_events() {
-    command="ada/ada --tokenfile ${token_file} --events test1 /${disk_path}/${dirname}/${testdir} --recursive --api ${api} --timeout 60"
+    command="ada/ada --tokenfile ${token_file} --events test1 /${disk_path}/${dirname}/${testdir} --recursive --api ${api} --timeout 60 --resume"
     echo "Running command:"
     echo $command
     eval $command >${stdoutE} 2>${stderrF} &
@@ -263,7 +263,7 @@ test_ada_delete() {
 
 # Subscribe to staging events in dCache folder
 test_ada_report_staged() {
-    command="ada/ada --tokenfile ${token_file} --report-staged test2 /${tape_path}/${dirname} --recursive --api ${api} --timeout 60"
+    command="ada/ada --tokenfile ${token_file} --report-staged test2 /${tape_path}/${dirname} --recursive --api ${api} --timeout 60 --resume"
     echo "Running command:"
     echo $command
     eval $command >${stdoutR} 2>${stderrF} &

--- a/tests/integration_test.sh
+++ b/tests/integration_test.sh
@@ -36,7 +36,7 @@ test_ada_mkdir() {
 
 # Subscribe to events in dCache folder
 test_ada_events() {
-    command="ada/ada --tokenfile ${token_file} --events test1 /${disk_path}/${dirname}/${testdir} --recursive --api ${api} --timeout 60 --resume"
+    command="ada/ada --tokenfile ${token_file} --events test1 /${disk_path}/${dirname}/${testdir} --recursive --api ${api} --timeout 60 --resume --force"
     echo "Running command:"
     echo $command
     eval $command >${stdoutE} 2>${stderrF} &
@@ -45,6 +45,17 @@ test_ada_events() {
     assertTrue "ada could not subscribe to events" $?
 }
 
+# Test error if channelname is already used
+test_ada_events_duplicate_channelname() {
+    command="ada/ada --tokenfile ${token_file} --events test1 /${disk_path}/${dirname}/${testdir} --recursive --api ${api} --timeout 60"
+    echo "Running command:"
+    echo $command
+    eval $command >${stdoutE} 2>${stderrF}
+    result=$?
+    assertEquals "ada did not return error code 1 as expected" 1 ${result} || return    
+    grep "ERROR" "${stderrF}"
+    assertTrue "ada events did not return ERROR message as expected" $?
+}
 
 # Move a file (created in oneTimeSetUp) to folder created in above test
 test_ada_mv1() {
@@ -263,13 +274,25 @@ test_ada_delete() {
 
 # Subscribe to staging events in dCache folder
 test_ada_report_staged() {
-    command="ada/ada --tokenfile ${token_file} --report-staged test2 /${tape_path}/${dirname} --recursive --api ${api} --timeout 60 --resume"
+    command="ada/ada --tokenfile ${token_file} --report-staged test2 /${tape_path}/${dirname} --recursive --api ${api} --timeout 60 --resume --force"
     echo "Running command:"
     echo $command
     eval $command >${stdoutR} 2>${stderrF} &
     sleep 3
     grep "path=/${tape_path}/${dirname}" "${stdoutR}"
     assertTrue "ada could not subscribe to staging events" $?
+}
+
+# Test error if channelname is already used
+test_ada_report_staged_duplicate_channelname() {
+    command="ada/ada --tokenfile ${token_file} --report-staged test2 /${disk_path}/${dirname}/${testdir} --recursive --api ${api} --timeout 60"
+    echo "Running command:"
+    echo $command
+    eval $command >${stdoutE} 2>${stderrF}
+    result=$?
+    assertEquals "ada did not return error code 1 as expected" 1 ${result} || return    
+    grep "ERROR" "${stderrF}"
+    assertTrue "ada report-staged did not return ERROR message as expected" $?
 }
 
 # Stage a file


### PR DESCRIPTION
If channelname is already used, --resume needs to be added to resume
If channelname is not stored locally, --force also needs to be added to resume