### PR TITLE
Replace /id api call with /namespace

### DIFF
--- a/ada/ada
+++ b/ada/ada
@@ -2096,16 +2096,12 @@ api_call () {
       | sort
       ;;
     stat )
-      pnfsid=$(get_pnfsid "$path")
-      if [ -z "$pnfsid" ] ; then
-        echo 1>&2 "ERROR: could not get file properties."
-        exit 1
-      fi
+      encoded_path=$(urlencode "$path")
       (
         $debug && set -x
         curl "${curl_authorization[@]}" \
              "${curl_options_common[@]}" \
-             -X GET "$api/id/$pnfsid" \
+             -X GET "$api/namespace/$encoded_path?children=true&locality=true&locations=true&qos=true&xattr=true&labels=true&checksum=true&optional=true" \
         | jq .
       )
       ;;

--- a/ada/ada
+++ b/ada/ada
@@ -1344,15 +1344,10 @@ get_checksums () {
   encoded_path=$(urlencode "$path")
   {
     echo -n -e "$path\t"
-    pnfsid=$(get_pnfsid "$path")
-    if [ -z "$pnfsid" ] ; then
-      echo "Could not get pnfsid."
-      return
-    fi
     {
       curl "${curl_authorization[@]}" \
            "${curl_options_no_errors[@]}" \
-           -X GET "$api/id/$pnfsid" \
+           -X GET "$api/namespace/$encoded_path?checksum=true" \
       | jq -r '.checksums | .[] | [ .type , .value ] | @tsv'
       # jq output is tab separated:
       # ADLER32\txxx


### PR DESCRIPTION
With `ada --checksum` and `ada --stat`, the API's `/id` call is used; mainly for historical reasons. But the `/id` API call will soon be changed. Anyway, we don't need it anymore, because we can now get the same info with the `/namespace` call, which even saves one API operation per file. 

This change replaces Ada's `/id` calls with `/namespace` calls. The output of `ada --checksum` is still the same. The output of `ada --stat` will probably be a bit different.