### PR TITLE
If size is empty (because upload not finished), show dash

### DIFF
--- a/ada/ada
+++ b/ada/ada
@@ -2404,7 +2404,7 @@ api_call () {
               | jq -r '.children | .[]
                      | [ .fileName ,
                          .fileType ,
-                         .size ,
+                         (.size // "-") ,
                          (.mtime / 1000 | strftime("%Y-%m-%d %H:%M UTC")) ,
                          if .targetQos then (.currentQos + "→" + .targetQos) else .currentQos end ,
                          .fileLocality ]


### PR DESCRIPTION
Example (file named "6" is being written):

```
[onno@mylaptop ~/git/SpiderScripts] % ada/ada --api https://dcacheview.grid.surfsara.nl:22880/api/v1 --longlist /pnfs/grid.sara.nl/data/users/onno/tape/test2/
5  14  2025-09-03 14:05 UTC  tape  ONLINE_AND_NEARLINE
6  -   2025-09-03 14:07 UTC  tape  NONE
```

Fixes #109 