### PR TITLE
Changes in release notes not ADA

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,27 @@
+# .github/release.yml
+
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+    authors:
+      - github-actions[bot]
+  categories:
+    - title: Features
+      labels:
+        - enhancement
+    - title: Fixes
+      labels:
+        - bug
+    - title: Documentation
+      labels:
+        - documentation
+    - title: Breaking Changes
+      labels:
+        - breaking-change        
+    - title: Dependencies
+      labels:
+        - dependencies
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/update_ada_version.yml
+++ b/.github/workflows/update_ada_version.yml
@@ -2,8 +2,6 @@ name: Update ada version
 
 on:
   push:
-    branches:
-      - '**'     # runs on any branch push
     tags:
       - 'v*'     # runs on tag push
   workflow_dispatch:   # manual trigger possible

--- a/ada/ada
+++ b/ada/ada
@@ -2,37 +2,11 @@
 
 # ADA - Advanced dCache API tool to manage data stored in dCache.
 #
-# Design: Natalie & Onno, SURFsara.
+# Design: Natalie Danezi, Haili Hu & Onno Zweers, SURF.
 #
 # Latest version is available at: https://github.com/sara-nl/SpiderScripts
-#
-# Changes:
-# 2025-06-17 - Haili   - Add option --delete-channel to delete a channel by name
-# 2025-04-10 - Haili   - Add options --resume and --force to events and report-staged
-# 2025-02-20 - Onno    - Fail early when a token is about to expire
-# 2025-02-18 - Haili   - Read config from <script_dir>/etc/ada.conf (as last option)
-# 2025-01-14 - Onno    - Add support for extended attributes
-# 2024-12-30 - Onno    - Add support for labels
-# 2024-12-27 - Onno    - Improved token validation
-# 2024-12-12 - Haili   - Implement unit testing
-# 2024-11-26 - Haili   - Add --recursive to --mkdir
-# 2024-09-12 - Haili   - Added bulk requests for staging and unstaging
-# 2024-08-24 - Haili   - Added option to use env var BEARER_TOKEN
-# 2020-11-04 - Onno    - Added link to Natalie's demo video
-# 2020-09-22 - Onno    - Support environment variables (ada_<variable>)
-# 2020-09-02 - Onno    - Added --space to get poolgroup capacity
-# 2020-08-23 - ahaupt  - Use env vars X509_USER_PROXY and X509_CERT_DIR if set
-# 2020-05-28 - Onno    - Allow curl options to be overridden in config files
-# 2020-04-21 - Onno    - Improved error handling
-# 2020-04-16 - Onno    - Add --recursive to --stage, --unstage, --checksum
-# 2020-04-03 - Onno    - Add --stat to get all possible file/dir info
-# 2020-03-13 - Onno    - Get server-sent events for files being staged
-# 2020-03-11 - Onno    - Added recursive deletes
-# 2020-03-04 - Onno    - Added X509 proxy authentication and netrc authentication
-# 2020-02-24 - Onno    - Don't show bearer tokens on command line
-# 2020-02-18 - Onno    - Recursion with server-sent events
-# 2020-02-14 - Onno    - Support for server-sent events
-# 2020-01-28 - Onno    - Created
+# For releases: https://github.com/sara-nl/SpiderScripts/releases
+
 
 usage() {
   cat <<-EOF


### PR DESCRIPTION
- Removed change notes in ada
- no version update on branches
- Added release.yml to customize automated release notes, see https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes. Note that we do not use the label `breaking-change` yet but I think it's a good idea so included it already.